### PR TITLE
Bumped the toml and lint dependencies to their latest,

### DIFF
--- a/embed/example/pubspec.yaml
+++ b/embed/example/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
     path: ../../embed_annotation
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.0
 repository: https://github.com/fujidaiti/embed.dart.git
 
 environment:
-  sdk: ">=3.0.5 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   analyzer: ">=5.2.0 <7.0.0"
@@ -14,7 +14,7 @@ dependencies:
   path: ^1.8.3
   yaml: ^3.1.2
   recase: ^4.1.0
-  toml: ^0.14.0
+  toml: ^0.15.0
   meta: ^1.9.1
   collection: ^1.17.2
 
@@ -24,7 +24,7 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.4.6
-  lints: ^2.1.1
+  lints: ^3.0.0
   mockito: ^5.4.2
   source_gen_test: ^1.0.6
   test: ^1.24.4

--- a/embed_annotation/pubspec.yaml
+++ b/embed_annotation/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^3.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.6
-  lints: ^2.0.0
+  lints: ^3.0.0
   embed:
     path: ../embed
 


### PR DESCRIPTION
 and moved to requiring Dart 3.2+ (because that's what toml bumped to).

Code compiles, and `dart test` seems to pass.