### PR TITLE
fix(embed): escape dollar symbol of JSON string literal

### DIFF
--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.1
+
+- fix(embed): escape dollar symbol of JSON string literal (#21 by @Jumpaku)
+
 ## 1.3.0
 
 - Update `toml` dependency to 0.15.0 (#17 by @bramp)

--- a/embed/lib/src/literal/dart_literals.dart
+++ b/embed/lib/src/literal/dart_literals.dart
@@ -72,7 +72,7 @@ class StringLiteral extends DartLiteral<String> {
 
   @override
   String toString() {
-    final literal = value.replaceAll('"', r'\"');
+    final literal = value.replaceAll('"', r'\"').replaceAll(r'$', r'\$');
     return '"$literal"';
   }
 }

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embed
 description: Code generation for embedding arbitrary file content into Dart code.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/fujidaiti/embed.dart.git
 
 environment:

--- a/embed/test/literal/literal_embedding_generator_test.dart
+++ b/embed/test/literal/literal_embedding_generator_test.dart
@@ -243,3 +243,14 @@ const _$mapPattern = {"a": 0, "b": 0.0, "c": true};
 """,
 )
 Map<String, dynamic>? mapPattern;
+
+@TestEmbedLiteral(
+  extension: "json",
+  content: r"""
+{ "dollar": "$" }
+""",
+  shouldGenerate: r"""
+const _$stringLiteralsDollar = (dollar: "\$");
+""",
+)
+var stringLiteralsDollar;


### PR DESCRIPTION
With the original version, `embed.dart` cannot generate a compilable Dart code if the source JSON has a string literal containing a dollar symbol ($). For example, the following code will be generated from {"dollar": "$"}:

```dart
const _$variable = (dollar: "$");
// the string literal "$" is not valid, which is a beginning of string interpolation.
```

In the revised version, I fixed it to generate the following code from that JSON:

```dart
const _$variable = (dollar: "\$");
// $ is escaped!
```

I also added a test case.