### PR TITLE
Dependency updates

### DIFF
--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.0
+
+- Upgrade dependencies (#22)
+
 ## 1.3.1
 
 - fix(embed): escape dollar symbol of JSON string literal (#21 by @Jumpaku)

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embed
 description: Code generation for embedding arbitrary file content into Dart code.
-version: 1.3.1
+version: 1.4.0
 repository: https://github.com/fujidaiti/embed.dart.git
 
 environment:

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -7,24 +7,24 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=5.2.0 <7.0.0"
-  embed_annotation: ^1.2.0
+  analyzer: ^6.5.0
+  embed_annotation: ^1.2.1
   build: ^2.4.1
-  source_gen: ^1.4.0
-  path: ^1.8.3
+  source_gen: ^1.5.0
+  path: ^1.9.0
   yaml: ^3.1.2
   recase: ^4.1.0
   toml: ^0.15.0
-  meta: ^1.9.1
-  collection: ^1.17.2
+  meta: ^1.15.0
+  collection: ^1.19.0
 
 dependency_overrides:
   embed_annotation:
     path: ../embed_annotation
 
 dev_dependencies:
-  build_runner: ^2.4.6
+  build_runner: ^2.4.11
   lints: ^3.0.0
-  mockito: ^5.4.2
+  mockito: ^5.4.4
   source_gen_test: ^1.0.6
-  test: ^1.24.4
+  test: ^1.25.7


### PR DESCRIPTION
The dependencies of `embed` package have been updated by running `dart pub upgrade --tighten`.