### PR TITLE
Update source_gen to version 3.0.0 and migrate to new element model API.

### DIFF
--- a/embed/lib/src/binary/binary_embedder.dart
+++ b/embed/lib/src/binary/binary_embedder.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:embed/src/common/embedder.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 
@@ -12,7 +12,7 @@ class BinaryEmbedder extends Embedder<EmbedBinary> {
 
   @override
   FutureOr<String> getEmbeddingOf(
-      File content, TopLevelVariableElement element) async {
+      File content, TopLevelVariableElement2 element) async {
     final bytes = await content.readAsBytes();
     if (config.base64) {
       return _encodeBase64(bytes);

--- a/embed/lib/src/common/embed_generator.dart
+++ b/embed/lib/src/common/embed_generator.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:embed/src/common/embedder.dart';
 import 'package:embed/src/common/resolve_content.dart' as r;
@@ -12,8 +12,8 @@ abstract class EmbeddingGenerator<E extends Embed>
     extends GeneratorForAnnotation<E> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-      Element element, ConstantReader annotation, BuildStep buildStep) async {
-    if (element is! TopLevelVariableElement) {
+      Element2 element, ConstantReader annotation, BuildStep buildStep) async {
+    if (element is! TopLevelVariableElement2) {
       throw InvalidGenerationSourceError(
         "Only top level variables can be annotated with $E",
         element: element,
@@ -31,13 +31,13 @@ abstract class EmbeddingGenerator<E extends Embed>
   }
 
   Future<String> _run(
-    TopLevelVariableElement element,
+    TopLevelVariableElement2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     final embedder = createEmbedderFrom(annotation);
     final content = resolveContent(embedder.config, buildStep);
-    final variable = "_\$${element.name}";
+    final variable = "_\$${element.name3}";
     final embedding = await embedder.getEmbeddingOf(content, element);
     return "const $variable = $embedding;";
   }

--- a/embed/lib/src/common/embedder.dart
+++ b/embed/lib/src/common/embedder.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 
 abstract class Embedder<E extends Embed> {
@@ -11,6 +11,6 @@ abstract class Embedder<E extends Embed> {
 
   FutureOr<String> getEmbeddingOf(
     File content,
-    TopLevelVariableElement element,
+    TopLevelVariableElement2 element,
   );
 }

--- a/embed/lib/src/literal/literal_embedder.dart
+++ b/embed/lib/src/literal/literal_embedder.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:embed/src/common/embedder.dart';
 import 'package:embed/src/common/errors.dart';
 import 'package:embed/src/literal/pattern_matching.dart';
@@ -18,7 +18,7 @@ class LiteralEmbedder extends Embedder<EmbedLiteral> {
 
   @override
   FutureOr<String> getEmbeddingOf(
-      File content, TopLevelVariableElement element) async {
+      File content, TopLevelVariableElement2 element) async {
     final value = await _parse(content);
     final expectedType = TypeConstraint.from(element.type);
     final preprocessed = Preprocessing(config.preprocessors).applyTo(value);

--- a/embed/lib/src/str/string_embedder.dart
+++ b/embed/lib/src/str/string_embedder.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:embed/src/common/embedder.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 
@@ -10,7 +10,7 @@ class StringEmbedder extends Embedder<EmbedStr> {
 
   @override
   FutureOr<String> getEmbeddingOf(
-      File content, TopLevelVariableElement element) async {
+      File content, TopLevelVariableElement2 element) async {
     final string = await content.readAsString();
     final r = config.raw ? "r" : "";
     return "$r'''\n$string\n'''";

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  analyzer: ^7.3.0
+  analyzer: ^7.7.1
   embed_annotation: ^1.2.1
-  build: ^2.4.2
-  source_gen: ^2.0.0
-  path: ^1.9.0
+  build: ^3.0.0
+  source_gen: ^3.0.0
+  path: ^1.9.1
   yaml: ^3.1.3
   recase: ^4.1.0
   toml: ^0.16.0

--- a/embed/test/utils/test_generator_mixin.dart
+++ b/embed/test/utils/test_generator_mixin.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/src/builder/build_step.dart';
 import 'package:embed/src/common/embed_generator.dart';
 import 'package:embed_annotation/embed_annotation.dart';
@@ -33,7 +33,7 @@ mixin TestGeneratorMixin<E extends Embed> on EmbeddingGenerator<E> {
 
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) {


### PR DESCRIPTION
Migrates the generator to the [new `Element` model](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md).

The `analyzer`, `build` and `source_gen` were updated to make this possible.

This change is needed for example when trying to use [`json_serializable`](https://pub.dev/packages/json_serializable/versions/6.10.0) version `6.10.0` and onwards in a project alongside `embed.dart`.

For this reason it would be great if this PR could be included in a new release soon.