### PR TITLE
Bump lints package.

### DIFF
--- a/embed/example/bin/example.dart
+++ b/embed/example/bin/example.dart
@@ -1,8 +1,6 @@
-// ignore_for_file: prefer_typing_uninitialized_variables
-
 import 'package:embed_annotation/embed_annotation.dart';
 
 @EmbedLiteral("/pubspec.yaml")
-var pubspec;
+dynamic pubspec;
 
 void main() {}

--- a/embed/example/pubspec.yaml
+++ b/embed/example/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
     path: ../../embed_annotation
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^6.0.0

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -24,7 +24,7 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.4.15
-  lints: ^5.1.1
+  lints: ^6.0.0
   mockito: ^5.4.5
   source_gen_test: ^1.1.1
   test: ^1.25.15

--- a/embed/test/binary/binary_embedding_generator_test.dart
+++ b/embed/test/binary/binary_embedding_generator_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: prefer_typing_uninitialized_variables
-
 import 'package:embed/src/binary/binary_embedding_generator.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 import 'package:source_gen_test/source_gen_test.dart';
@@ -55,7 +53,7 @@ class TestBinary extends ShouldGenerate implements TestAnnotation, EmbedBinary {
 const _$embedAsList = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 """,
 )
-var embedAsList;
+dynamic embedAsList;
 
 // The content should be embedded as base64
 @TestBinary(
@@ -66,4 +64,4 @@ var embedAsList;
 const _$embedAsBase64 = 'AQIDBAUGBwgJCg==';
 """,
 )
-var embedAsBase64;
+dynamic embedAsBase64;

--- a/embed/test/literal/literal_embedding_generator_test.dart
+++ b/embed/test/literal/literal_embedding_generator_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: prefer_typing_uninitialized_variables
-
 import 'package:embed/src/literal/literal_embedding_generator.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 import 'package:source_gen_test/source_gen_test.dart';
@@ -58,7 +56,7 @@ class TestEmbedLiteral extends ShouldGenerate
 const _$integerLiterals = (a: 0);
 """,
 )
-var integerLiterals;
+dynamic integerLiterals;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -76,7 +74,7 @@ Map<String, int>? hexDecimalIntegerLiteral;
 const _$floatLiterals = (a: 0.0, b: -0.0);
 """,
 )
-var floatLiterals;
+dynamic floatLiterals;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -87,7 +85,7 @@ var floatLiterals;
 const _$stringLiterals = (a: "a", b: "\"b\"", c: "'c'");
 """,
 )
-var stringLiterals;
+dynamic stringLiterals;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -96,7 +94,7 @@ var stringLiterals;
 const _$booleanLiterals = (a: true, b: false);
 """,
 )
-var booleanLiterals;
+dynamic booleanLiterals;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -105,7 +103,7 @@ var booleanLiterals;
 const _$nullLiteral = (a: null);
 """,
 )
-var nullLiteral;
+dynamic nullLiteral;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -114,7 +112,7 @@ var nullLiteral;
 const _$arrayLiteral = [0, 1, 2, 3, 4, 5];
 """,
 )
-var arrayLiteral;
+dynamic arrayLiteral;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -123,7 +121,7 @@ var arrayLiteral;
 const _$recordLiteral = (a: 0, b: 0.0, c: true);
 """,
 )
-var recordLiteral;
+dynamic recordLiteral;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -132,7 +130,7 @@ var recordLiteral;
 const _$mapLiteral = {"#": 0};
 """,
 )
-var mapLiteral;
+dynamic mapLiteral;
 
 // Any of the reserved Dart keywords should be prefixed with a '$' sign
 // when it is used as a record field name.
@@ -215,7 +213,7 @@ const _$reservedWordsAsRecordField = (
 );
 """,
 )
-var reservedWordsAsRecordField;
+dynamic reservedWordsAsRecordField;
 
 @TestEmbedLiteral(
   extension: "json",
@@ -253,4 +251,4 @@ Map<String, dynamic>? mapPattern;
 const _$stringLiteralsDollar = (dollar: "\$");
 """,
 )
-var stringLiteralsDollar;
+dynamic stringLiteralsDollar;

--- a/embed/test/str/str_embedding_generator_test.dart
+++ b/embed/test/str/str_embedding_generator_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: prefer_typing_uninitialized_variables
-
 import 'package:embed/src/str/str_embedding_generator.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 import 'package:source_gen_test/source_gen_test.dart';
@@ -58,7 +56,7 @@ This is a single line text
 ''';
 """,
 )
-var singleLine;
+dynamic singleLine;
 
 // The content should be embedded as is, even if it has multiple lines.
 @TestStrLiteral(
@@ -73,7 +71,7 @@ The second line of the multi-line text
 ''';
 """,
 )
-var multiLine;
+dynamic multiLine;
 
 // // Leanding and trailing blank lines should be preserved.
 @TestStrLiteral(
@@ -92,7 +90,7 @@ and a trailing blank line.
 ''';
 """,
 )
-var textWithBlankLines;
+dynamic textWithBlankLines;
 
 // Content should be able to contain qutation marks.
 @TestStrLiteral(
@@ -104,7 +102,7 @@ a "b" c 'd' e \"f\'
 ''';
 """,
 )
-var quotationMarks;
+dynamic quotationMarks;
 
 // Content should be embedded as a regular string literal.
 @TestStrLiteral(
@@ -117,4 +115,4 @@ This is a single line text
 ''';
 """,
 )
-var regularStringLiteral;
+dynamic regularStringLiteral;

--- a/embed_annotation/pubspec.yaml
+++ b/embed_annotation/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dev_dependencies:
-  lints: ^5.1.1
+  lints: ^6.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.6
-  lints: ^3.0.0
+  lints: ^6.0.0
   embed:
     path: ../embed
 


### PR DESCRIPTION
Bumps the `lints` package to version `6.0.0`, removes the 
```dart
// ignore_for_file: prefer_typing_uninitialized_variables
```
comments and instead declares the unintialized variables using `dynamic`.

**I am not so sure about this change.**
Please let me know what you think.

The alternative would be to keep using `var` and adding:
```dart
// ignore_for_file: prefer_typing_uninitialized_variables, strict_top_level_inference
```
to the top of the files.