### PR TITLE
Use minimum `analyzer` version required by `source_gen` v3

### DIFF
--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  analyzer: ^7.7.1
+  analyzer: ^7.4.0
   embed_annotation: ^1.2.1
   build: ^3.0.0
   source_gen: ^3.0.0


### PR DESCRIPTION
Since `source_gen` v3.0.0 only requires `analyzer` v7.4.0 or higher, there's no need to upgrade `analyzer` beyond v7.4.0.