### PR TITLE
Loosen analyzer version constraint

### DIFF
--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  analyzer: ^7.4.0
+  analyzer: '>=7.4.0 <9.0.0'
   embed_annotation: ^1.2.1
   build: ^3.0.0
   source_gen: ^3.0.0


### PR DESCRIPTION
This also allows using `analyzer` versions 8+ with `embed`.

The change is inspired by [this PR made to `json_serializable`](https://github.com/google/json_serializable.dart/pull/1516/files#diff-59d21f713f667efb5a2285557d9d18be37c619c20bdb2e886336dddd8605e84eR18).