### PR TITLE
Replace deprecated TypeChecker.fromRuntime with TypeChecker.typeNamed

### DIFF
--- a/embed/lib/src/binary/binary_embedding_generator.dart
+++ b/embed/lib/src/binary/binary_embedding_generator.dart
@@ -7,7 +7,8 @@ import 'package:source_gen/source_gen.dart';
 class BinaryEmbeddingGenerator extends EmbeddingGenerator<EmbedBinary> {
   @override
   Embedder<EmbedBinary> createEmbedderFrom(ConstantReader annotation) {
-    assert(annotation.instanceOf(TypeChecker.fromRuntime(EmbedBinary)));
+    assert(annotation.instanceOf(
+        TypeChecker.typeNamed(EmbedBinary, inPackage: "embed_annotation")));
     return BinaryEmbedder(EmbedBinary(
       annotation.read("path").stringValue,
       base64: annotation.read("base64").boolValue,

--- a/embed/lib/src/literal/literal_embedding_generator.dart
+++ b/embed/lib/src/literal/literal_embedding_generator.dart
@@ -8,7 +8,8 @@ import 'package:source_gen/source_gen.dart';
 class LiteralEmbeddingGenerator extends EmbeddingGenerator<EmbedLiteral> {
   @override
   Embedder<EmbedLiteral> createEmbedderFrom(ConstantReader annotation) {
-    assert(annotation.instanceOf(TypeChecker.fromRuntime(EmbedLiteral)));
+    assert(annotation.instanceOf(
+        TypeChecker.typeNamed(EmbedLiteral, inPackage: "embed_annotation")));
     final contentPath = annotation.read("path").stringValue;
     final preprocessors = annotation
         .read("preprocessors")
@@ -27,13 +28,16 @@ class LiteralEmbeddingGenerator extends EmbeddingGenerator<EmbedLiteral> {
 }
 
 Preprocessor _readPreprocessor(ConstantReader reader) {
-  if (reader.instanceOf(TypeChecker.fromRuntime(Recase))) {
+  if (reader.instanceOf(
+      TypeChecker.typeNamed(Recase, inPackage: "embed_annotation"))) {
     return Preprocessor.recase;
   }
-  if (reader.instanceOf(TypeChecker.fromRuntime(EscapeReservedKeywords))) {
+  if (reader.instanceOf(TypeChecker.typeNamed(EscapeReservedKeywords,
+      inPackage: "embed_annotation"))) {
     return Preprocessor.escapeReservedKeywords;
   }
-  if (reader.instanceOf(TypeChecker.fromRuntime(Replace))) {
+  if (reader.instanceOf(
+      TypeChecker.typeNamed(Replace, inPackage: "embed_annotation"))) {
     return Replace(
       reader.read("pattern").stringValue,
       reader.read("replacement").stringValue,

--- a/embed/lib/src/str/str_embedding_generator.dart
+++ b/embed/lib/src/str/str_embedding_generator.dart
@@ -7,7 +7,8 @@ import 'package:source_gen/source_gen.dart';
 class StrEmbeddingGenerator extends EmbeddingGenerator<EmbedStr> {
   @override
   Embedder<EmbedStr> createEmbedderFrom(ConstantReader annotation) {
-    assert(annotation.instanceOf(TypeChecker.fromRuntime(EmbedStr)));
+    assert(annotation.instanceOf(
+        TypeChecker.typeNamed(EmbedStr, inPackage: "embed_annotation")));
     return StringEmbedder(EmbedStr(
       annotation.read("path").stringValue,
       raw: annotation.read("raw").boolValue,

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^7.4.0
   embed_annotation: ^1.2.1
   build: ^3.0.0
-  source_gen: ^3.0.0
+  source_gen: ^3.1.0
   path: ^1.9.1
   yaml: ^3.1.3
   recase: ^4.1.0


### PR DESCRIPTION
Recently a new version of [`source_gen`](https://pub.dev/packages/source_gen/changelog#310) was released, which now deprecates the use of `TypeChecker.fromRuntime`.

Unfortunately the recommended replacement `TypeChecker.typeNamed` is only available in `source_gen: ^3.1.0`, so I had to bump it.

The alternative to keep compatibility with `source_gen: ^3.0.0` would be to adjust `analysis_options.yaml` like so:
```diff
include: package:lints/recommended.yaml

+analyzer:
+  errors:
+    deprecated_member_use: ignore
```