### PR TITLE
Loosen source_gen and build version constraints.

### DIFF
--- a/embed/lib/src/binary/binary_embedder.dart
+++ b/embed/lib/src/binary/binary_embedder.dart
@@ -1,3 +1,7 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/embed/lib/src/common/embed_generator.dart
+++ b/embed/lib/src/common/embed_generator.dart
@@ -1,3 +1,7 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 

--- a/embed/lib/src/common/embedder.dart
+++ b/embed/lib/src/common/embedder.dart
@@ -1,3 +1,7 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 

--- a/embed/lib/src/literal/literal_embedder.dart
+++ b/embed/lib/src/literal/literal_embedder.dart
@@ -1,3 +1,7 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/embed/lib/src/str/string_embedder.dart
+++ b/embed/lib/src/str/string_embedder.dart
@@ -1,3 +1,7 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 

--- a/embed/pubspec.yaml
+++ b/embed/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   analyzer: '>=7.4.0 <9.0.0'
   embed_annotation: ^1.2.1
-  build: ^3.0.0
-  source_gen: ^3.1.0
+  build: '>=3.0.0 <5.0.0'
+  source_gen: '>=3.1.0 <5.0.0'
   path: ^1.9.1
   yaml: ^3.1.3
   recase: ^4.1.0

--- a/embed/test/utils/test_generator_mixin.dart
+++ b/embed/test/utils/test_generator_mixin.dart
@@ -1,9 +1,13 @@
+// Ignore deprecated_member_use in order to support a wider range of build and
+// source_gen
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:analyzer/dart/element/element2.dart';
-import 'package:build/src/builder/build_step.dart';
+import 'package:build/build.dart';
 import 'package:embed/src/common/embed_generator.dart';
 import 'package:embed_annotation/embed_annotation.dart';
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
Allow
```yaml
  build: '>=3.0.0 <5.0.0'
  source_gen: '>=3.1.0 <5.0.0'
```

This change is once again inspired by a [PR made to `json_serializable`](https://github.com/google/json_serializable.dart/pull/1525).

I've had to silence some occurrences of the `deprecated_member_use` lint in order to maintain compatibility with `build` version `3.x` and `source_gen` version `3.x`. Once we are ready to force downstream users to use versions `4.x`, the deprecated members can be replaced by their actual replacements (for example `Element2` back to `Element` as outlined in the [element model migration guide of the `analyzer` package](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md)).

As far as I can tell, this shouldn't be a breaking change, therefore bumping the version to `1.6.1` would be enough in case only this PR would be included in the next release.

Let's hope that the dust around these `build_runner` related major version changes settles soon, so I don't have to continue making these PRs ;)